### PR TITLE
[#59] 상품 상세 페이지에서 판매자 팔로우 여부 조회 및 팔로우 추가/해제

### DIFF
--- a/src/main/java/com/fx/funxtion/domain/follow/controller/ApiV1FollowController.java
+++ b/src/main/java/com/fx/funxtion/domain/follow/controller/ApiV1FollowController.java
@@ -47,6 +47,7 @@ public class ApiV1FollowController {
     }
 
 
+
     // 팔로우 추가 or 해제
     @PostMapping("follower")
     public RsData<Long> updateFollow(@RequestBody FollowUpdateRequest followUpdateRequest) {

--- a/src/main/java/com/fx/funxtion/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/fx/funxtion/domain/follow/repository/FollowRepository.java
@@ -24,4 +24,6 @@ public interface FollowRepository extends JpaRepository<UserFollows, Long> {
     boolean existsByFromMemberIdAndToMemberId(Long fromMemberId, Long toMemberId);
 
     UserFollows findByFromMemberIdAndToMemberId(Long fromMemberId, Long toMemberId);
+
+
 }

--- a/src/main/java/com/fx/funxtion/domain/product/dto/ProductDetailResponse.java
+++ b/src/main/java/com/fx/funxtion/domain/product/dto/ProductDetailResponse.java
@@ -35,12 +35,14 @@ public class ProductDetailResponse {
     private List<BidDto> bids = new ArrayList<>();
     private int favorites;
     private boolean isFavorite = false;
+    private boolean isFollow = false;
 
-    public ProductDetailResponse(Product p) {
+    public ProductDetailResponse(Product p, Boolean isFollow) {
         BeanUtils.copyProperties(p, this);
         this.seller = new MemberDto(p.getMember());
         this.images = p.getImages().stream().map(ProductImageDto::new).toList();
         this.bids  = p.getBids().stream().map(BidDto::new).toList();
         this.favorites = p.getFavorites().size();
+        this.isFollow = isFollow;
     }
 }

--- a/src/main/java/com/fx/funxtion/domain/product/service/ProductService.java
+++ b/src/main/java/com/fx/funxtion/domain/product/service/ProductService.java
@@ -1,5 +1,6 @@
 package com.fx.funxtion.domain.product.service;
 
+import com.fx.funxtion.domain.follow.repository.FollowRepository;
 import com.fx.funxtion.domain.member.entity.Member;
 import com.fx.funxtion.domain.member.repository.MemberRepository;
 import com.fx.funxtion.domain.product.dto.*;
@@ -34,6 +35,7 @@ public class ProductService {
     private final BidRepository bidRepository;
     private final ProductImageRepository productImageRepository;
     private final ImageService imageService;
+    private final FollowRepository followRepository;
 
     public RsData<ProductCreateResponse> createProduct(ProductCreateRequest productCreateRequest, MultipartFile[] multipartFiles) {
         Member member = memberRepository.findById(productCreateRequest.getStoreId())
@@ -245,12 +247,20 @@ public class ProductService {
         if (optionalProduct.isEmpty()) {
             return RsData.of("500", "상품 조회 실패!");
         }
+        boolean isFollowing = followRepository.existsByFromMemberIdAndToMemberId(userId, optionalProduct.get().getMember().getId());
+        ProductDetailResponse productDetailResponse;
 
-        ProductDetailResponse productDetailResponse = new ProductDetailResponse(optionalProduct.get());
+        if(isFollowing == true) {
+            productDetailResponse = new ProductDetailResponse(optionalProduct.get(), isFollowing);
+        } else {
+            productDetailResponse = new ProductDetailResponse(optionalProduct.get(), false);
+        }
+
         if (userId != null) {
             Favorite favor = favoriteRepository.findByUserIdAndProductId(userId, productId);
             productDetailResponse.setFavorite(favor != null);
         }
+
 
         return RsData.of("200", "상품 조회 성공!", productDetailResponse);
     }

--- a/src/main/java/com/fx/funxtion/domain/product/service/ProductService.java
+++ b/src/main/java/com/fx/funxtion/domain/product/service/ProductService.java
@@ -248,13 +248,7 @@ public class ProductService {
             return RsData.of("500", "상품 조회 실패!");
         }
         boolean isFollowing = followRepository.existsByFromMemberIdAndToMemberId(userId, optionalProduct.get().getMember().getId());
-        ProductDetailResponse productDetailResponse;
-
-        if(isFollowing == true) {
-            productDetailResponse = new ProductDetailResponse(optionalProduct.get(), isFollowing);
-        } else {
-            productDetailResponse = new ProductDetailResponse(optionalProduct.get(), false);
-        }
+        ProductDetailResponse productDetailResponse = new ProductDetailResponse(optionalProduct.get(), isFollowing);
 
         if (userId != null) {
             Favorite favor = favoriteRepository.findByUserIdAndProductId(userId, productId);


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #59 

## 📝작업 내용

>상품 상세 페이지에서 판매자 팔로우 여부 조회 및 팔로우 추가/해제

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
