### PR TITLE
[#63] Fix 관리자 가1:1문의 조회시 Member태이블을 조인하여 email을표시하도록 수정 

### DIFF
--- a/src/main/java/com/fx/funxtion/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/fx/funxtion/domain/notice/service/NoticeService.java
@@ -40,7 +40,7 @@ public class NoticeService {
         noticeRepository.save(notice);
         Optional<Notice> optionalNotice = noticeRepository.findById(notice.getId());
 
-        return optionalNotice.map(q ->RsData.of("200","1:1 문의 등록 성공",new NoticeCreateResponse(q))).orElseGet(() -> RsData.of("500","1:1 문의 등록 실패"));
+        return optionalNotice.map(q ->RsData.of("200","공지 등록 성공",new NoticeCreateResponse(q))).orElseGet(() -> RsData.of("500","1:1 문의 등록 실패"));
     }
 
     public RsData<NoticeCreateResponse> getNoticeDetail(Long noticeId){

--- a/src/main/java/com/fx/funxtion/domain/qna/dto/QnaDto.java
+++ b/src/main/java/com/fx/funxtion/domain/qna/dto/QnaDto.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 @ToString
 public class QnaDto {
     private Long id;
-    private Long userId;
+    private String email;
     private String qnaTitle;
     private String categoryId;
     private String qnaContent;
@@ -25,6 +25,6 @@ public class QnaDto {
 
     public QnaDto(Qna qna) {
         BeanUtils.copyProperties(qna, this);
-
+        this.email = qna.getMember().getEmail();
     }
 }

--- a/src/main/java/com/fx/funxtion/domain/qna/entity/Qna.java
+++ b/src/main/java/com/fx/funxtion/domain/qna/entity/Qna.java
@@ -1,42 +1,45 @@
-package com.fx.funxtion.domain.qna.entity;
+    package com.fx.funxtion.domain.qna.entity;
 
 
-import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.experimental.SuperBuilder;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+    import com.fx.funxtion.domain.member.entity.Member;
+    import jakarta.persistence.*;
+    import lombok.AllArgsConstructor;
+    import lombok.Getter;
+    import lombok.NoArgsConstructor;
+    import lombok.Setter;
+    import lombok.experimental.SuperBuilder;
+    import org.springframework.data.annotation.CreatedDate;
+    import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+    import java.time.LocalDateTime;
 
-@Entity
-@Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-@SuperBuilder
-@EntityListeners(AuditingEntityListener.class)
-@Table(name="qna_log")
-public class Qna  {
-    @Id
-    @Column(updatable = false)
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Entity
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @SuperBuilder
+    @EntityListeners(AuditingEntityListener.class)
+    @Table(name="qna_log")
+    public class Qna  {
+        @Id
+        @Column(updatable = false)
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        private Long id;
 
-    private String categoryId;
+        private String categoryId;
 
-    private Long userId;
+        @OneToOne
+        @JoinColumn(name = "user_id")
+        private Member member;
 
-    private String qnaTitle;
+        private String qnaTitle;
 
-    private String qnaContent;
+        private String qnaContent;
 
-    private String qnaAnswer;
-    @CreatedDate
-    @Column(updatable = false)
-    private LocalDateTime createDate;
+        private String qnaAnswer;
+        @CreatedDate
+        @Column(updatable = false)
+        private LocalDateTime createDate;
 
-}
+    }

--- a/src/main/java/com/fx/funxtion/domain/qna/repository/QnaRepository.java
+++ b/src/main/java/com/fx/funxtion/domain/qna/repository/QnaRepository.java
@@ -1,14 +1,18 @@
 package com.fx.funxtion.domain.qna.repository;
 
+import com.fx.funxtion.domain.member.entity.Member;
 import com.fx.funxtion.domain.qna.entity.Qna;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
+
 public interface QnaRepository extends JpaRepository<Qna, Long> {
 
-    Page<Qna> findByUserId(Long userId, Pageable pageable);
-    Page<Qna> findAll(Pageable pageable);
+
+
+    Page<Qna> findByMember(Member member, Pageable pageable);
+    Page<Qna> findAllBy(Pageable pageable);
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#63
> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
[#63] 관리자 가1:1문의 조회시 Member태이블을 조인하여 email을표시하도록 수정 
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
