### PR TITLE
[#77] 채팅방 새로고침 버튼 버그 수정

### DIFF
--- a/src/main/java/com/fx/funxtion/domain/chat/controller/ApiV1chatRoomController.java
+++ b/src/main/java/com/fx/funxtion/domain/chat/controller/ApiV1chatRoomController.java
@@ -50,6 +50,24 @@ public class ApiV1chatRoomController {
     }
 
     /**
+     * 특정 채팅방 새로고침
+     * @param id
+     * @return RsData<ChatRoomReloadResponse><
+     */
+    @GetMapping("/reload/{id}")
+    public RsData<ChatRoomReloadResponse> reloadRoom(@RequestParam("id") String id) {
+        Long roomId = Long.parseLong(id);
+        try {
+            RsData<ChatRoomReloadResponse> chatRoomReloadResponse = chatService.getChatRoomReload(roomId);
+            return RsData.of(chatRoomReloadResponse.getResultCode(), chatRoomReloadResponse.getMsg(), chatRoomReloadResponse.getData());
+        } catch (Exception e) {
+            return RsData.of("500", e.getMessage());
+        }
+
+    }
+
+
+    /**
      * 채팅방 생성,변경
      * @param chatRoomCreateRequest
      * @return RsData<Long>

--- a/src/main/java/com/fx/funxtion/domain/chat/dto/ChatRoomReloadResponse.java
+++ b/src/main/java/com/fx/funxtion/domain/chat/dto/ChatRoomReloadResponse.java
@@ -1,0 +1,28 @@
+package com.fx.funxtion.domain.chat.dto;
+
+import com.fx.funxtion.domain.chat.entity.ChatRoom;
+import com.fx.funxtion.domain.member.dto.MemberDto;
+import com.fx.funxtion.domain.product.dto.ProductDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@ToString
+@Setter
+public class ChatRoomReloadResponse {
+
+    private ProductDto product;
+
+    public ChatRoomReloadResponse(ChatRoom chatRoom) {
+
+        this.product = new ProductDto(chatRoom.getProduct());
+
+    }
+
+}

--- a/src/main/java/com/fx/funxtion/domain/chat/service/ChatService.java
+++ b/src/main/java/com/fx/funxtion/domain/chat/service/ChatService.java
@@ -149,5 +149,13 @@ public class ChatService {
                 .orElseGet(() -> RsData.of("500", "방 조회 실패!"));
     }
 
+    public RsData<ChatRoomReloadResponse> getChatRoomReload(Long roomId) throws Exception {
+        Long id = roomId;
+        Optional<ChatRoom> optionalChatRoom = chatRoomRepository.findById(id);
+
+        return optionalChatRoom.map(chatRoom -> RsData.of("200", roomId+"번방 새로고침 성공", new ChatRoomReloadResponse(chatRoom)))
+                .orElseGet(() -> RsData.of("500", "방 조회 실패"));
+    }
+
 
 }

--- a/src/main/java/com/fx/funxtion/global/websocket/handler/SocketHandler.java
+++ b/src/main/java/com/fx/funxtion/global/websocket/handler/SocketHandler.java
@@ -93,7 +93,7 @@ public class SocketHandler extends TextWebSocketHandler {
                 // 안전거래 버튼 클릭 시 DB 저장.
                 SafePayments safePaymentsEx = safePaymentsRepository.findByProductIdAndSellerIdAndBuyerId(obj.get("productId").getAsLong(), obj.get("sellerId").getAsLong(), obj.get("buyerId").getAsLong());
                 SafePayments safePayments;
-                if (safePaymentsEx == null && temp.keySet().size() >= 2 && obj.get("safe").getAsString() == "true") {
+                if (safePaymentsEx == null && temp.keySet().size() >= 2 && obj.get("safe").getAsString() == "true" && obj.get("justWord").getAsString() == "false") {
                     safePayments = SafePayments.builder()
                             .productId(obj.get("productId").getAsLong())
                             .sellerId(obj.get("sellerId").getAsLong())


### PR DESCRIPTION
채팅방 새로고침 버튼 누를 시 채팅 내용
복사되는 버그 수정(아예 다른 api로 상품 정보만 변경되도록 하였음)

## 연관된 이슈

> ex) #77 

## 📝작업 내용

> 채팅방 새로고침 버튼 누를 시 채팅 내용
복사되는 버그 수정(아예 다른 api로 상품 정보만 응답하여 변경되도록 하였음)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
