### PR TITLE
[#79] 팔로우 카드에 상품수 / 팔로잉 수 잘못 표시되던거 수정

### DIFF
--- a/src/main/java/com/fx/funxtion/domain/member/service/FollowService.java
+++ b/src/main/java/com/fx/funxtion/domain/member/service/FollowService.java
@@ -42,8 +42,8 @@ public class FollowService {
         Page<UserFollows> userFollowsPage = followRepository.findAllByFromMemberId(fromId, PageRequest.of(page, size));
 
         return userFollowsPage.map(userFollows -> {
-            Long productCnt = productRepository.countByMemberId(userFollows.getFromMember().getId());
-            Long followerCnt = followRepository.countByToMemberId(userFollows.getFromMember().getId());
+            Long productCnt = productRepository.countByMemberId(userFollows.getToMember().getId());
+            Long followerCnt = followRepository.countByToMemberId(userFollows.getToMember().getId());
             boolean isFollowing = followRepository.existsByFromMemberIdAndToMemberId(fromId, userFollows.getToMember().getId());
             int followCnt = list.size();
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #79 

## 📝작업 내용

> 팔로우 카드에 상품수 / 팔로잉 수 잘못 표시되던거 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
